### PR TITLE
Add title screen with world size selection and Perlin terrain

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -1,0 +1,9 @@
+# Project State
+
+## Finished
+- Basic voxel world rendering with free camera controls.
+- Title screen with adjustable world size, Start Game and Exit buttons.
+- Perlin noise terrain generation on game start.
+
+## WIP
+- None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -1,0 +1,5 @@
+# AGENT_INFO
+
+- Implemented a title screen with adjustable world size and exit/start buttons using the Bevy 0.16 UI system.
+- Added Perlin noise terrain generation via `fastnoise-lite` when starting the game.
+- Introduced game states for menu and playing, with camera controls active only during gameplay.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use bevy::app::AppExit;
 use bevy::input::mouse::MouseMotion;
 use bevy::pbr::MeshMaterial3d;
 use bevy::prelude::*;
@@ -5,6 +6,32 @@ use bevy::render::mesh::Mesh3d;
 use bevy::render::renderer::RenderAdapterInfo;
 use bevy::render::settings::{Backends, RenderCreation, WgpuSettings};
 use bevy::render::RenderPlugin;
+use fastnoise_lite::{FastNoiseLite, NoiseType};
+
+// === Application State ===
+
+#[derive(States, Default, Debug, Clone, Eq, PartialEq, Hash)]
+enum AppState {
+    #[default]
+    Menu,
+    Playing,
+}
+
+// === Resources ===
+
+#[derive(Resource)]
+struct WorldParams {
+    width: i32,
+    depth: i32,
+}
+
+impl Default for WorldParams {
+    fn default() -> Self {
+        Self { width: 10, depth: 10 }
+    }
+}
+
+// === Components ===
 
 #[derive(Component)]
 struct PlayerCam {
@@ -12,8 +39,33 @@ struct PlayerCam {
     pitch: f32,
 }
 
+#[derive(Component)]
+struct MenuRoot;
+
+#[derive(Component)]
+struct DimText {
+    dim: Dimension,
+}
+
+#[derive(Component)]
+struct DimButton {
+    dim: Dimension,
+    delta: i32,
+}
+
+#[derive(Component)]
+struct StartButton;
+
+#[derive(Component)]
+struct ExitButton;
+
+#[derive(Clone, Copy)]
+enum Dimension {
+    Width,
+    Depth,
+}
+
 fn main() {
-    println!("Starting program");
     // Try DX12 first; if it still fails, change to Backends::VULKAN and re-run.
     let forced = WgpuSettings {
         backends: Some(Backends::DX12), // or Backends::VULKAN
@@ -36,17 +88,215 @@ fn main() {
                     ..Default::default()
                 }),
         )
-        .add_systems(Startup, (setup, print_backend))
-        .add_systems(Update, (mouse_look, keyboard_move))
+        .init_resource::<WorldParams>()
+        .init_state::<AppState>()
+        // Menu systems
+        .add_systems(OnEnter(AppState::Menu), menu_setup)
+        .add_systems(Update, menu_actions.run_if(in_state(AppState::Menu)))
+        .add_systems(Update, update_dim_texts.run_if(in_state(AppState::Menu)))
+        .add_systems(OnExit(AppState::Menu), menu_cleanup)
+        // Game systems
+        .add_systems(OnEnter(AppState::Playing), setup_game)
+        .add_systems(Update, (mouse_look, keyboard_move).run_if(in_state(AppState::Playing)))
+        .add_systems(Startup, print_backend)
         .run();
 }
 
-fn setup(
+// === Menu ===
+
+fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
+    let root = commands
+        .spawn((
+            Node {
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                flex_direction: FlexDirection::Column,
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..Default::default()
+            },
+            MenuRoot,
+        ))
+        .id();
+
+    // Title
+    commands.entity(root).with_children(|parent| {
+        parent.spawn((
+            Text::new("Project Rube"),
+            TextFont {
+                font_size: 40.0,
+                ..Default::default()
+            },
+        ));
+
+        spawn_dim_row(parent, Dimension::Width, params.width);
+        spawn_dim_row(parent, Dimension::Depth, params.depth);
+
+        // Start button
+        parent
+            .spawn((
+                Button,
+                Node {
+                    padding: UiRect::axes(Val::Px(10.0), Val::Px(5.0)),
+                    margin: UiRect::all(Val::Px(5.0)),
+                    ..Default::default()
+                },
+                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                StartButton,
+            ))
+            .with_children(|p| {
+                p.spawn((
+                    Text::new("Start Game"),
+                    TextFont { font_size: 24.0, ..Default::default() },
+                    TextColor::default(),
+                ));
+            });
+
+        // Exit button
+        parent
+            .spawn((
+                Button,
+                Node {
+                    padding: UiRect::axes(Val::Px(10.0), Val::Px(5.0)),
+                    margin: UiRect::all(Val::Px(5.0)),
+                    ..Default::default()
+                },
+                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                ExitButton,
+            ))
+            .with_children(|p| {
+                p.spawn((
+                    Text::new("Exit"),
+                    TextFont { font_size: 24.0, ..Default::default() },
+                    TextColor::default(),
+                ));
+            });
+    });
+}
+
+fn spawn_dim_row(parent: &mut ChildSpawnerCommands, dim: Dimension, value: i32) {
+    parent
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                margin: UiRect::all(Val::Px(5.0)),
+                ..Default::default()
+            },
+        ))
+        .with_children(|row| {
+            let label = match dim {
+                Dimension::Width => "Width:",
+                Dimension::Depth => "Depth:",
+            };
+            row.spawn((
+                Text::new(format!("{} {}", label, value)),
+                TextFont { font_size: 24.0, ..Default::default() },
+                TextColor::default(),
+                DimText { dim },
+            ));
+
+            // minus button
+            row
+                .spawn((
+                    Button,
+                    Node {
+                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
+                        margin: UiRect::left(Val::Px(5.0)),
+                        ..Default::default()
+                    },
+                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                    DimButton { dim, delta: -1 },
+                ))
+                .with_children(|p| {
+                    p.spawn((
+                        Text::new("-"),
+                        TextFont { font_size: 24.0, ..Default::default() },
+                        TextColor::default(),
+                    ));
+                });
+
+            // plus button
+            row
+                .spawn((
+                    Button,
+                    Node {
+                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
+                        margin: UiRect::left(Val::Px(5.0)),
+                        ..Default::default()
+                    },
+                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                    DimButton { dim, delta: 1 },
+                ))
+                .with_children(|p| {
+                    p.spawn((
+                        Text::new("+"),
+                        TextFont { font_size: 24.0, ..Default::default() },
+                        TextColor::default(),
+                    ));
+                });
+        });
+}
+
+fn menu_actions(
+    mut interaction_q: Query<(&Interaction, Option<&DimButton>, Option<&StartButton>, Option<&ExitButton>), Changed<Interaction>>,
+    mut params: ResMut<WorldParams>,
+    mut next_state: ResMut<NextState<AppState>>,
+    mut exit: EventWriter<AppExit>,
+) {
+    for (interaction, dim_button, start, exit_button) in &mut interaction_q {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+
+        if let Some(dim_button) = dim_button {
+            let value = match dim_button.dim {
+                Dimension::Width => &mut params.width,
+                Dimension::Depth => &mut params.depth,
+            };
+            *value = (*value + dim_button.delta).max(1);
+        }
+
+        if start.is_some() {
+            next_state.set(AppState::Playing);
+        }
+
+        if exit_button.is_some() {
+            exit.write(AppExit::Success);
+        }
+    }
+}
+
+fn update_dim_texts(params: Res<WorldParams>, mut q: Query<(&DimText, &mut Text)>) {
+    if !params.is_changed() {
+        return;
+    }
+    for (dim, mut text) in &mut q {
+        let label = match dim.dim {
+            Dimension::Width => "Width:",
+            Dimension::Depth => "Depth:",
+        };
+        *text = Text::new(format!("{} {}", label, match dim.dim {
+            Dimension::Width => params.width,
+            Dimension::Depth => params.depth,
+        }));
+    }
+}
+
+fn menu_cleanup(mut commands: Commands, q: Query<Entity, With<MenuRoot>>) {
+    for e in &q {
+        commands.entity(e).despawn();
+    }
+}
+
+// === Game Setup ===
+
+fn setup_game(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    params: Res<WorldParams>,
 ) {
-    println!("Running Setup");
     // camera
     commands.spawn((
         Camera3d::default(),
@@ -61,12 +311,16 @@ fn setup(
         Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
-    // simple voxel world
+    // generate terrain using Perlin noise
+    let mut noise = FastNoiseLite::with_seed(0);
+    noise.set_noise_type(Some(NoiseType::Perlin));
+
     let cube = meshes.add(Cuboid::default());
     let material = materials.add(Color::srgb_u8(150, 150, 150));
-    for x in -5..=5 {
-        for z in -5..=5 {
-            let height = if (x + z) % 2 == 0 { 1 } else { 2 };
+    for x in 0..params.width {
+        for z in 0..params.depth {
+            let n = noise.get_noise_2d(x as f32 * 0.1, z as f32 * 0.1);
+            let height = (n * 3.0).round() as i32 + 1;
             for y in 0..height {
                 commands.spawn((
                     Mesh3d(cube.clone()),
@@ -76,8 +330,9 @@ fn setup(
             }
         }
     }
-    println!("Finished Setup");
 }
+
+// === Player Controls ===
 
 fn mouse_look(
     mut mouse_events: EventReader<MouseMotion>,
@@ -90,7 +345,7 @@ fn mouse_look(
     if delta == Vec2::ZERO {
         return;
     }
-    if let Ok((mut transform, mut cam)) = q.get_single_mut() {
+    if let Ok((mut transform, mut cam)) = q.single_mut() {
         let sensitivity = 0.002;
         cam.yaw -= delta.x * sensitivity;
         cam.pitch -= delta.y * sensitivity;
@@ -105,7 +360,7 @@ fn keyboard_move(
     keys: Res<ButtonInput<KeyCode>>,
     mut q: Query<&mut Transform, With<PlayerCam>>,
 ) {
-    if let Ok(mut transform) = q.get_single_mut() {
+    if let Ok(mut transform) = q.single_mut() {
         let mut direction = Vec3::ZERO;
         let forward = transform.forward();
         let right = transform.right();


### PR DESCRIPTION
## Summary
- Introduce a menu state with a title screen offering start and exit buttons and adjustable world width/depth.
- Generate basic Perlin noise terrain when starting the game and enable camera controls only during gameplay.
- Document progress in new `AGENT_INFO.md` and `ProjectState.md` files.

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68acc94404bc832394e509e3eddb9e4e