### PR TITLE
Add MenuCamera for menu UI

### DIFF
--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -3,3 +3,4 @@
 - Implemented a title screen with adjustable world size and exit/start buttons using the Bevy 0.16 UI system.
 - Added Perlin noise terrain generation via `fastnoise-lite` when starting the game.
 - Introduced game states for menu and playing, with camera controls active only during gameplay.
+- Added a dedicated MenuCamera and cleanup logic for spawning and despawning the menu UI camera.

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ struct PlayerCam {
 struct MenuRoot;
 
 #[derive(Component)]
+struct MenuCamera;
+
+#[derive(Component)]
 struct DimText {
     dim: Dimension,
 }
@@ -118,6 +121,8 @@ fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
             MenuRoot,
         ))
         .id();
+
+    commands.spawn((Camera2d, MenuCamera));
 
     // Title
     commands.entity(root).with_children(|parent| {
@@ -283,8 +288,15 @@ fn update_dim_texts(params: Res<WorldParams>, mut q: Query<(&DimText, &mut Text)
     }
 }
 
-fn menu_cleanup(mut commands: Commands, q: Query<Entity, With<MenuRoot>>) {
-    for e in &q {
+fn menu_cleanup(
+    mut commands: Commands,
+    roots: Query<Entity, With<MenuRoot>>,
+    cams: Query<Entity, With<MenuCamera>>,
+) {
+    for e in &roots {
+        commands.entity(e).despawn();
+    }
+    for e in &cams {
         commands.entity(e).despawn();
     }
 }


### PR DESCRIPTION
## Summary
- add `MenuCamera` marker component
- spawn and clean up a 2D camera for menu rendering
- document the new menu camera behavior

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68acd17db1788323b8f7fd81a91ca618