### PR TITLE
Fix perlin noise generation and modularize main

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -3,7 +3,7 @@
 ## Finished
 - Basic voxel world rendering with free camera controls.
 - Title screen with adjustable world size, Start Game and Exit buttons.
-- Perlin noise terrain generation on game start.
+- Perlin noise terrain generation on game start with corrected frequency for varied height.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -4,3 +4,5 @@
 - Added Perlin noise terrain generation via `fastnoise-lite` when starting the game.
 - Introduced game states for menu and playing, with camera controls active only during gameplay.
 - Added a dedicated MenuCamera and cleanup logic for spawning and despawning the menu UI camera.
+- Corrected Perlin noise frequency so terrain heights vary properly.
+- Refactored gameplay, menu, player controls, and world resources into separate modules to slim down `main.rs`.

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,0 +1,51 @@
+use bevy::pbr::MeshMaterial3d;
+use bevy::prelude::*;
+use bevy::render::mesh::Mesh3d;
+use fastnoise_lite::{FastNoiseLite, NoiseType};
+
+use crate::player::PlayerCam;
+use crate::world::WorldParams;
+
+pub fn setup_game(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    params: Res<WorldParams>,
+) {
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 2.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        PlayerCam { yaw: 0.0, pitch: 0.0 },
+        Visibility::default(),
+    ));
+
+    // light
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    let mut noise = FastNoiseLite::with_seed(0);
+    noise.set_noise_type(Some(NoiseType::Perlin));
+    noise.set_frequency(Some(0.1));
+
+    let cube = meshes.add(Cuboid::default());
+    let material = materials.add(Color::srgb_u8(150, 150, 150));
+
+    for x in 0..params.width {
+        for z in 0..params.depth {
+            let n = noise.get_noise_2d(x as f32, z as f32);
+            let height = (n * 3.0).round() as i32 + 1;
+            if height > 0 {
+                for y in 0..height {
+                    commands.spawn((
+                        Mesh3d(cube.clone()),
+                        MeshMaterial3d(material.clone()),
+                        Transform::from_xyz(x as f32, y as f32 - 1.0, z as f32),
+                    ));
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,77 +1,23 @@
-use bevy::app::AppExit;
-use bevy::input::mouse::MouseMotion;
-use bevy::pbr::MeshMaterial3d;
+mod state;
+mod world;
+mod menu;
+mod game;
+mod player;
+
 use bevy::prelude::*;
-use bevy::render::mesh::Mesh3d;
 use bevy::render::renderer::RenderAdapterInfo;
 use bevy::render::settings::{Backends, RenderCreation, WgpuSettings};
 use bevy::render::RenderPlugin;
-use fastnoise_lite::{FastNoiseLite, NoiseType};
 
-// === Application State ===
-
-#[derive(States, Default, Debug, Clone, Eq, PartialEq, Hash)]
-enum AppState {
-    #[default]
-    Menu,
-    Playing,
-}
-
-// === Resources ===
-
-#[derive(Resource)]
-struct WorldParams {
-    width: i32,
-    depth: i32,
-}
-
-impl Default for WorldParams {
-    fn default() -> Self {
-        Self { width: 10, depth: 10 }
-    }
-}
-
-// === Components ===
-
-#[derive(Component)]
-struct PlayerCam {
-    yaw: f32,
-    pitch: f32,
-}
-
-#[derive(Component)]
-struct MenuRoot;
-
-#[derive(Component)]
-struct MenuCamera;
-
-#[derive(Component)]
-struct DimText {
-    dim: Dimension,
-}
-
-#[derive(Component)]
-struct DimButton {
-    dim: Dimension,
-    delta: i32,
-}
-
-#[derive(Component)]
-struct StartButton;
-
-#[derive(Component)]
-struct ExitButton;
-
-#[derive(Clone, Copy)]
-enum Dimension {
-    Width,
-    Depth,
-}
+use game::setup_game;
+use menu::{menu_actions, menu_cleanup, menu_setup, update_dim_texts};
+use player::{keyboard_move, mouse_look};
+use state::AppState;
+use world::WorldParams;
 
 fn main() {
-    // Try DX12 first; if it still fails, change to Backends::VULKAN and re-run.
     let forced = WgpuSettings {
-        backends: Some(Backends::DX12), // or Backends::VULKAN
+        backends: Some(Backends::DX12),
         ..Default::default()
     };
 
@@ -93,315 +39,16 @@ fn main() {
         )
         .init_resource::<WorldParams>()
         .init_state::<AppState>()
-        // Menu systems
         .add_systems(OnEnter(AppState::Menu), menu_setup)
         .add_systems(Update, menu_actions.run_if(in_state(AppState::Menu)))
         .add_systems(Update, update_dim_texts.run_if(in_state(AppState::Menu)))
         .add_systems(OnExit(AppState::Menu), menu_cleanup)
-        // Game systems
         .add_systems(OnEnter(AppState::Playing), setup_game)
         .add_systems(Update, (mouse_look, keyboard_move).run_if(in_state(AppState::Playing)))
         .add_systems(Startup, print_backend)
         .run();
 }
 
-// === Menu ===
-
-fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
-    let root = commands
-        .spawn((
-            Node {
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                flex_direction: FlexDirection::Column,
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                ..Default::default()
-            },
-            MenuRoot,
-        ))
-        .id();
-
-    commands.spawn((Camera2d, MenuCamera));
-
-    // Title
-    commands.entity(root).with_children(|parent| {
-        parent.spawn((
-            Text::new("Project Rube"),
-            TextFont {
-                font_size: 40.0,
-                ..Default::default()
-            },
-        ));
-
-        spawn_dim_row(parent, Dimension::Width, params.width);
-        spawn_dim_row(parent, Dimension::Depth, params.depth);
-
-        // Start button
-        parent
-            .spawn((
-                Button,
-                Node {
-                    padding: UiRect::axes(Val::Px(10.0), Val::Px(5.0)),
-                    margin: UiRect::all(Val::Px(5.0)),
-                    ..Default::default()
-                },
-                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
-                StartButton,
-            ))
-            .with_children(|p| {
-                p.spawn((
-                    Text::new("Start Game"),
-                    TextFont { font_size: 24.0, ..Default::default() },
-                    TextColor::default(),
-                ));
-            });
-
-        // Exit button
-        parent
-            .spawn((
-                Button,
-                Node {
-                    padding: UiRect::axes(Val::Px(10.0), Val::Px(5.0)),
-                    margin: UiRect::all(Val::Px(5.0)),
-                    ..Default::default()
-                },
-                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
-                ExitButton,
-            ))
-            .with_children(|p| {
-                p.spawn((
-                    Text::new("Exit"),
-                    TextFont { font_size: 24.0, ..Default::default() },
-                    TextColor::default(),
-                ));
-            });
-    });
-}
-
-fn spawn_dim_row(parent: &mut ChildSpawnerCommands, dim: Dimension, value: i32) {
-    parent
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Row,
-                align_items: AlignItems::Center,
-                margin: UiRect::all(Val::Px(5.0)),
-                ..Default::default()
-            },
-        ))
-        .with_children(|row| {
-            let label = match dim {
-                Dimension::Width => "Width:",
-                Dimension::Depth => "Depth:",
-            };
-            row.spawn((
-                Text::new(format!("{} {}", label, value)),
-                TextFont { font_size: 24.0, ..Default::default() },
-                TextColor::default(),
-                DimText { dim },
-            ));
-
-            // minus button
-            row
-                .spawn((
-                    Button,
-                    Node {
-                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
-                        margin: UiRect::left(Val::Px(5.0)),
-                        ..Default::default()
-                    },
-                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
-                    DimButton { dim, delta: -1 },
-                ))
-                .with_children(|p| {
-                    p.spawn((
-                        Text::new("-"),
-                        TextFont { font_size: 24.0, ..Default::default() },
-                        TextColor::default(),
-                    ));
-                });
-
-            // plus button
-            row
-                .spawn((
-                    Button,
-                    Node {
-                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
-                        margin: UiRect::left(Val::Px(5.0)),
-                        ..Default::default()
-                    },
-                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
-                    DimButton { dim, delta: 1 },
-                ))
-                .with_children(|p| {
-                    p.spawn((
-                        Text::new("+"),
-                        TextFont { font_size: 24.0, ..Default::default() },
-                        TextColor::default(),
-                    ));
-                });
-        });
-}
-
-fn menu_actions(
-    mut interaction_q: Query<(&Interaction, Option<&DimButton>, Option<&StartButton>, Option<&ExitButton>), Changed<Interaction>>,
-    mut params: ResMut<WorldParams>,
-    mut next_state: ResMut<NextState<AppState>>,
-    mut exit: EventWriter<AppExit>,
-) {
-    for (interaction, dim_button, start, exit_button) in &mut interaction_q {
-        if *interaction != Interaction::Pressed {
-            continue;
-        }
-
-        if let Some(dim_button) = dim_button {
-            let value = match dim_button.dim {
-                Dimension::Width => &mut params.width,
-                Dimension::Depth => &mut params.depth,
-            };
-            *value = (*value + dim_button.delta).max(1);
-        }
-
-        if start.is_some() {
-            next_state.set(AppState::Playing);
-        }
-
-        if exit_button.is_some() {
-            exit.write(AppExit::Success);
-        }
-    }
-}
-
-fn update_dim_texts(params: Res<WorldParams>, mut q: Query<(&DimText, &mut Text)>) {
-    if !params.is_changed() {
-        return;
-    }
-    for (dim, mut text) in &mut q {
-        let label = match dim.dim {
-            Dimension::Width => "Width:",
-            Dimension::Depth => "Depth:",
-        };
-        *text = Text::new(format!("{} {}", label, match dim.dim {
-            Dimension::Width => params.width,
-            Dimension::Depth => params.depth,
-        }));
-    }
-}
-
-fn menu_cleanup(
-    mut commands: Commands,
-    roots: Query<Entity, With<MenuRoot>>,
-    cams: Query<Entity, With<MenuCamera>>,
-) {
-    for e in &roots {
-        commands.entity(e).despawn();
-    }
-    for e in &cams {
-        commands.entity(e).despawn();
-    }
-}
-
-// === Game Setup ===
-
-fn setup_game(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    params: Res<WorldParams>,
-) {
-    // camera
-    commands.spawn((
-        Camera3d::default(),
-        Transform::from_xyz(0.0, 2.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        PlayerCam { yaw: 0.0, pitch: 0.0 },
-        Visibility::default(),
-    ));
-
-    // light
-    commands.spawn((
-        DirectionalLight::default(),
-        Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
-    ));
-
-    // generate terrain using Perlin noise
-    let mut noise = FastNoiseLite::with_seed(0);
-    noise.set_noise_type(Some(NoiseType::Perlin));
-
-    let cube = meshes.add(Cuboid::default());
-    let material = materials.add(Color::srgb_u8(150, 150, 150));
-    for x in 0..params.width {
-        for z in 0..params.depth {
-            let n = noise.get_noise_2d(x as f32 * 0.1, z as f32 * 0.1);
-            let height = (n * 3.0).round() as i32 + 1;
-            for y in 0..height {
-                commands.spawn((
-                    Mesh3d(cube.clone()),
-                    MeshMaterial3d(material.clone()),
-                    Transform::from_xyz(x as f32, y as f32 - 1.0, z as f32),
-                ));
-            }
-        }
-    }
-}
-
-// === Player Controls ===
-
-fn mouse_look(
-    mut mouse_events: EventReader<MouseMotion>,
-    mut q: Query<(&mut Transform, &mut PlayerCam)>,
-) {
-    let mut delta = Vec2::ZERO;
-    for ev in mouse_events.read() {
-        delta += ev.delta;
-    }
-    if delta == Vec2::ZERO {
-        return;
-    }
-    if let Ok((mut transform, mut cam)) = q.single_mut() {
-        let sensitivity = 0.002;
-        cam.yaw -= delta.x * sensitivity;
-        cam.pitch -= delta.y * sensitivity;
-        cam.pitch = cam.pitch.clamp(-1.54, 1.54);
-        transform.rotation =
-            Quat::from_axis_angle(Vec3::Y, cam.yaw) * Quat::from_axis_angle(Vec3::X, cam.pitch);
-    }
-}
-
-fn keyboard_move(
-    time: Res<Time>,
-    keys: Res<ButtonInput<KeyCode>>,
-    mut q: Query<&mut Transform, With<PlayerCam>>,
-) {
-    if let Ok(mut transform) = q.single_mut() {
-        let mut direction = Vec3::ZERO;
-        let forward = transform.forward();
-        let right = transform.right();
-        if keys.pressed(KeyCode::KeyW) {
-            direction += *forward;
-        }
-        if keys.pressed(KeyCode::KeyS) {
-            direction -= *forward;
-        }
-        if keys.pressed(KeyCode::KeyA) {
-            direction -= *right;
-        }
-        if keys.pressed(KeyCode::KeyD) {
-            direction += *right;
-        }
-        if keys.pressed(KeyCode::Space) {
-            direction += Vec3::Y;
-        }
-        if keys.pressed(KeyCode::ShiftLeft) {
-            direction -= Vec3::Y;
-        }
-        if direction.length_squared() > 0.0 {
-            let speed = 5.0;
-            transform.translation += direction.normalize() * speed * time.delta_secs();
-        }
-    }
-}
-
 fn print_backend(info: Res<RenderAdapterInfo>) {
     println!("Backend: {:?} | Adapter: {}", info.backend, info.name);
 }
-

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,0 +1,224 @@
+use bevy::app::AppExit;
+use bevy::ecs::hierarchy::ChildSpawnerCommands;
+use bevy::prelude::*;
+
+use crate::state::AppState;
+use crate::world::WorldParams;
+
+#[derive(Component)]
+pub struct MenuRoot;
+
+#[derive(Component)]
+pub struct MenuCamera;
+
+#[derive(Component)]
+pub struct DimText {
+    pub dim: Dimension,
+}
+
+#[derive(Component)]
+pub struct DimButton {
+    pub dim: Dimension,
+    pub delta: i32,
+}
+
+#[derive(Component)]
+pub struct StartButton;
+
+#[derive(Component)]
+pub struct ExitButton;
+
+#[derive(Clone, Copy)]
+pub enum Dimension {
+    Width,
+    Depth,
+}
+
+pub fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
+    let root = commands
+        .spawn((
+            Node {
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                flex_direction: FlexDirection::Column,
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..Default::default()
+            },
+            MenuRoot,
+        ))
+        .id();
+
+    commands.spawn((Camera2d, MenuCamera));
+
+    commands.entity(root).with_children(|parent| {
+        parent.spawn((
+            Text::new("Project Rube"),
+            TextFont {
+                font_size: 40.0,
+                ..Default::default()
+            },
+        ));
+
+        spawn_dim_row(parent, Dimension::Width, params.width);
+        spawn_dim_row(parent, Dimension::Depth, params.depth);
+
+        parent
+            .spawn((
+                Button,
+                Node {
+                    padding: UiRect::axes(Val::Px(10.0), Val::Px(5.0)),
+                    margin: UiRect::all(Val::Px(5.0)),
+                    ..Default::default()
+                },
+                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                StartButton,
+            ))
+            .with_children(|p| {
+                p.spawn((
+                    Text::new("Start Game"),
+                    TextFont { font_size: 24.0, ..Default::default() },
+                    TextColor::default(),
+                ));
+            });
+
+        parent
+            .spawn((
+                Button,
+                Node {
+                    padding: UiRect::axes(Val::Px(10.0), Val::Px(5.0)),
+                    margin: UiRect::all(Val::Px(5.0)),
+                    ..Default::default()
+                },
+                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                ExitButton,
+            ))
+            .with_children(|p| {
+                p.spawn((
+                    Text::new("Exit"),
+                    TextFont { font_size: 24.0, ..Default::default() },
+                    TextColor::default(),
+                ));
+            });
+    });
+}
+
+fn spawn_dim_row(parent: &mut ChildSpawnerCommands, dim: Dimension, value: i32) {
+    parent
+        .spawn((
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                margin: UiRect::all(Val::Px(5.0)),
+                ..Default::default()
+            },
+        ))
+        .with_children(|row| {
+            let label = match dim {
+                Dimension::Width => "Width:",
+                Dimension::Depth => "Depth:",
+            };
+            row.spawn((
+                Text::new(format!("{} {}", label, value)),
+                TextFont { font_size: 24.0, ..Default::default() },
+                TextColor::default(),
+                DimText { dim },
+            ));
+
+            row
+                .spawn((
+                    Button,
+                    Node {
+                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
+                        margin: UiRect::left(Val::Px(5.0)),
+                        ..Default::default()
+                    },
+                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                    DimButton { dim, delta: -1 },
+                ))
+                .with_children(|p| {
+                    p.spawn((
+                        Text::new("-"),
+                        TextFont { font_size: 24.0, ..Default::default() },
+                        TextColor::default(),
+                    ));
+                });
+
+            row
+                .spawn((
+                    Button,
+                    Node {
+                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
+                        margin: UiRect::left(Val::Px(5.0)),
+                        ..Default::default()
+                    },
+                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                    DimButton { dim, delta: 1 },
+                ))
+                .with_children(|p| {
+                    p.spawn((
+                        Text::new("+"),
+                        TextFont { font_size: 24.0, ..Default::default() },
+                        TextColor::default(),
+                    ));
+                });
+        });
+}
+
+pub fn menu_actions(
+    mut interaction_q: Query<(&Interaction, Option<&DimButton>, Option<&StartButton>, Option<&ExitButton>), Changed<Interaction>>,
+    mut params: ResMut<WorldParams>,
+    mut next_state: ResMut<NextState<AppState>>,
+    mut exit: EventWriter<AppExit>,
+) {
+    for (interaction, dim_button, start, exit_button) in &mut interaction_q {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+
+        if let Some(dim_button) = dim_button {
+            let value = match dim_button.dim {
+                Dimension::Width => &mut params.width,
+                Dimension::Depth => &mut params.depth,
+            };
+            *value = (*value + dim_button.delta).max(1);
+        }
+
+        if start.is_some() {
+            next_state.set(AppState::Playing);
+        }
+
+        if exit_button.is_some() {
+            exit.write(AppExit::Success);
+        }
+    }
+}
+
+pub fn update_dim_texts(params: Res<WorldParams>, mut q: Query<(&DimText, &mut Text)>) {
+    if !params.is_changed() {
+        return;
+    }
+    for (dim, mut text) in &mut q {
+        let label = match dim.dim {
+            Dimension::Width => "Width:",
+            Dimension::Depth => "Depth:",
+        };
+        *text = Text::new(format!("{} {}", label, match dim.dim {
+            Dimension::Width => params.width,
+            Dimension::Depth => params.depth,
+        }));
+    }
+}
+
+pub fn menu_cleanup(
+    mut commands: Commands,
+    roots: Query<Entity, With<MenuRoot>>,
+    cams: Query<Entity, With<MenuCamera>>,
+) {
+    for e in &roots {
+        commands.entity(e).despawn();
+    }
+    for e in &cams {
+        commands.entity(e).despawn();
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,63 @@
+use bevy::input::mouse::MouseMotion;
+use bevy::prelude::*;
+
+#[derive(Component)]
+pub struct PlayerCam {
+    pub yaw: f32,
+    pub pitch: f32,
+}
+
+pub fn mouse_look(
+    mut mouse_events: EventReader<MouseMotion>,
+    mut q: Query<(&mut Transform, &mut PlayerCam)>,
+) {
+    let mut delta = Vec2::ZERO;
+    for ev in mouse_events.read() {
+        delta += ev.delta;
+    }
+    if delta == Vec2::ZERO {
+        return;
+    }
+    if let Ok((mut transform, mut cam)) = q.single_mut() {
+        let sensitivity = 0.002;
+        cam.yaw -= delta.x * sensitivity;
+        cam.pitch -= delta.y * sensitivity;
+        cam.pitch = cam.pitch.clamp(-1.54, 1.54);
+        transform.rotation =
+            Quat::from_axis_angle(Vec3::Y, cam.yaw) * Quat::from_axis_angle(Vec3::X, cam.pitch);
+    }
+}
+
+pub fn keyboard_move(
+    time: Res<Time>,
+    keys: Res<ButtonInput<KeyCode>>,
+    mut q: Query<&mut Transform, With<PlayerCam>>,
+) {
+    if let Ok(mut transform) = q.single_mut() {
+        let mut direction = Vec3::ZERO;
+        let forward = transform.forward();
+        let right = transform.right();
+        if keys.pressed(KeyCode::KeyW) {
+            direction += *forward;
+        }
+        if keys.pressed(KeyCode::KeyS) {
+            direction -= *forward;
+        }
+        if keys.pressed(KeyCode::KeyA) {
+            direction -= *right;
+        }
+        if keys.pressed(KeyCode::KeyD) {
+            direction += *right;
+        }
+        if keys.pressed(KeyCode::Space) {
+            direction += Vec3::Y;
+        }
+        if keys.pressed(KeyCode::ShiftLeft) {
+            direction -= Vec3::Y;
+        }
+        if direction.length_squared() > 0.0 {
+            let speed = 5.0;
+            transform.translation += direction.normalize() * speed * time.delta_secs();
+        }
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,8 @@
+use bevy::prelude::*;
+
+#[derive(States, Default, Debug, Clone, Eq, PartialEq, Hash)]
+pub enum AppState {
+    #[default]
+    Menu,
+    Playing,
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,0 +1,13 @@
+use bevy::prelude::*;
+
+#[derive(Resource)]
+pub struct WorldParams {
+    pub width: i32,
+    pub depth: i32,
+}
+
+impl Default for WorldParams {
+    fn default() -> Self {
+        Self { width: 10, depth: 10 }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix Perlin noise world generation by setting an explicit frequency and using unscaled coordinates
- Refactor monolithic `main.rs` into modular menu, game, player, world, and state modules
- Update agent documentation and project state

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68acd48a765c83238dd71d544aad86b2