### PR TITLE
Use chunk-based world generation with adjustable view width

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -2,9 +2,9 @@
 
 ## Finished
 - Basic voxel world rendering with free camera controls.
-- Title screen with adjustable world size, Start Game and Exit buttons.
+- Title screen with adjustable view width, Start Game and Exit buttons.
 - Perlin noise terrain generation on game start with corrected frequency for varied height.
-- World generation now defaults to 512x512 blocks with stacked 2D noise and 3D noise caves.
+- World generation uses 32×32×32 chunks with a configurable view width radius and a maximum height of 128 blocks, plus stacked 2D noise and 3D noise caves.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -1,11 +1,11 @@
 # AGENT_INFO
 
-- Implemented a title screen with adjustable world size and exit/start buttons using the Bevy 0.16 UI system.
+- Implemented a title screen with adjustable view width and exit/start buttons using the Bevy 0.16 UI system.
 - Added Perlin noise terrain generation via `fastnoise-lite` when starting the game.
 - Introduced game states for menu and playing, with camera controls active only during gameplay.
 - Added a dedicated MenuCamera and cleanup logic for spawning and despawning the menu UI camera.
 - Corrected Perlin noise frequency so terrain heights vary properly.
 - Refactored gameplay, menu, player controls, and world resources into separate modules to slim down `main.rs`.
-- Expanded world generation to a default 512x512 area.
 - Stacked multiple 2D Perlin noise layers for wide-spread terrain variation.
 - Applied 3D Perlin noise to carve caves, cliffs, and ravines without exposing void spaces.
+- Switched to chunk-based world generation using 32×32×32 chunks with a configurable view width radius (default 4) and a maximum height of 128 blocks.

--- a/src/game.rs
+++ b/src/game.rs
@@ -4,7 +4,7 @@ use bevy::render::mesh::Mesh3d;
 use fastnoise_lite::{FastNoiseLite, NoiseType};
 
 use crate::player::PlayerCam;
-use crate::world::WorldParams;
+use crate::world::{CHUNK_SIZE, MAX_HEIGHT, WorldParams};
 
 pub fn setup_game(
     mut commands: Commands,
@@ -44,18 +44,32 @@ pub fn setup_game(
     let cube = meshes.add(Cuboid::default());
     let material = materials.add(Color::srgb_u8(150, 150, 150));
 
-    for x in 0..params.width {
-        for z in 0..params.depth {
-            let base = base_noise.get_noise_2d(x as f32, z as f32);
-            let detail = detail_noise.get_noise_2d(x as f32, z as f32);
-            let height = ((base * 20.0) + (detail * 5.0) + 20.0).round().max(1.0) as i32;
-            for y in 0..height {
-                if y == 0 || cave_noise.get_noise_3d(x as f32, y as f32, z as f32) > 0.0 {
-                    commands.spawn((
-                        Mesh3d(cube.clone()),
-                        MeshMaterial3d(material.clone()),
-                        Transform::from_xyz(x as f32, y as f32, z as f32),
-                    ));
+    for cx in -params.view_width..=params.view_width {
+        for cz in -params.view_width..=params.view_width {
+            let chunk_x = cx * CHUNK_SIZE;
+            let chunk_z = cz * CHUNK_SIZE;
+            for x in 0..CHUNK_SIZE {
+                for z in 0..CHUNK_SIZE {
+                    let world_x = chunk_x + x;
+                    let world_z = chunk_z + z;
+                    let base = base_noise.get_noise_2d(world_x as f32, world_z as f32);
+                    let detail = detail_noise.get_noise_2d(world_x as f32, world_z as f32);
+                    let height = ((base * 20.0) + (detail * 5.0) + 20.0)
+                        .round()
+                        .clamp(1.0, (MAX_HEIGHT - 1) as f32)
+                        as i32;
+                    for y in 0..height {
+                        if y == 0
+                            || cave_noise.get_noise_3d(world_x as f32, y as f32, world_z as f32)
+                                > 0.0
+                        {
+                            commands.spawn((
+                                Mesh3d(cube.clone()),
+                                MeshMaterial3d(material.clone()),
+                                Transform::from_xyz(world_x as f32, y as f32, world_z as f32),
+                            ));
+                        }
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,16 @@
+mod game;
+mod menu;
+mod player;
 mod state;
 mod world;
-mod menu;
-mod game;
-mod player;
 
 use bevy::prelude::*;
+use bevy::render::RenderPlugin;
 use bevy::render::renderer::RenderAdapterInfo;
 use bevy::render::settings::{Backends, RenderCreation, WgpuSettings};
-use bevy::render::RenderPlugin;
 
 use game::setup_game;
-use menu::{menu_actions, menu_cleanup, menu_setup, update_dim_texts};
+use menu::{menu_actions, menu_cleanup, menu_setup, update_view_text};
 use player::{keyboard_move, mouse_look};
 use state::AppState;
 use world::WorldParams;
@@ -41,10 +41,13 @@ fn main() {
         .init_state::<AppState>()
         .add_systems(OnEnter(AppState::Menu), menu_setup)
         .add_systems(Update, menu_actions.run_if(in_state(AppState::Menu)))
-        .add_systems(Update, update_dim_texts.run_if(in_state(AppState::Menu)))
+        .add_systems(Update, update_view_text.run_if(in_state(AppState::Menu)))
         .add_systems(OnExit(AppState::Menu), menu_cleanup)
         .add_systems(OnEnter(AppState::Playing), setup_game)
-        .add_systems(Update, (mouse_look, keyboard_move).run_if(in_state(AppState::Playing)))
+        .add_systems(
+            Update,
+            (mouse_look, keyboard_move).run_if(in_state(AppState::Playing)),
+        )
         .add_systems(Startup, print_backend)
         .run();
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -12,13 +12,10 @@ pub struct MenuRoot;
 pub struct MenuCamera;
 
 #[derive(Component)]
-pub struct DimText {
-    pub dim: Dimension,
-}
+pub struct ViewText;
 
 #[derive(Component)]
-pub struct DimButton {
-    pub dim: Dimension,
+pub struct ViewButton {
     pub delta: i32,
 }
 
@@ -27,12 +24,6 @@ pub struct StartButton;
 
 #[derive(Component)]
 pub struct ExitButton;
-
-#[derive(Clone, Copy)]
-pub enum Dimension {
-    Width,
-    Depth,
-}
 
 pub fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
     let root = commands
@@ -60,8 +51,7 @@ pub fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
             },
         ));
 
-        spawn_dim_row(parent, Dimension::Width, params.width);
-        spawn_dim_row(parent, Dimension::Depth, params.depth);
+        spawn_view_row(parent, params.view_width);
 
         parent
             .spawn((
@@ -77,7 +67,10 @@ pub fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
             .with_children(|p| {
                 p.spawn((
                     Text::new("Start Game"),
-                    TextFont { font_size: 24.0, ..Default::default() },
+                    TextFont {
+                        font_size: 24.0,
+                        ..Default::default()
+                    },
                     TextColor::default(),
                 ));
             });
@@ -96,92 +89,100 @@ pub fn menu_setup(mut commands: Commands, params: Res<WorldParams>) {
             .with_children(|p| {
                 p.spawn((
                     Text::new("Exit"),
-                    TextFont { font_size: 24.0, ..Default::default() },
+                    TextFont {
+                        font_size: 24.0,
+                        ..Default::default()
+                    },
                     TextColor::default(),
                 ));
             });
     });
 }
 
-fn spawn_dim_row(parent: &mut ChildSpawnerCommands, dim: Dimension, value: i32) {
+fn spawn_view_row(parent: &mut ChildSpawnerCommands, value: i32) {
     parent
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Row,
-                align_items: AlignItems::Center,
-                margin: UiRect::all(Val::Px(5.0)),
-                ..Default::default()
-            },
-        ))
+        .spawn((Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            margin: UiRect::all(Val::Px(5.0)),
+            ..Default::default()
+        },))
         .with_children(|row| {
-            let label = match dim {
-                Dimension::Width => "Width:",
-                Dimension::Depth => "Depth:",
-            };
             row.spawn((
-                Text::new(format!("{} {}", label, value)),
-                TextFont { font_size: 24.0, ..Default::default() },
+                Text::new(format!("View Width: {}", value)),
+                TextFont {
+                    font_size: 24.0,
+                    ..Default::default()
+                },
                 TextColor::default(),
-                DimText { dim },
+                ViewText,
             ));
 
-            row
-                .spawn((
-                    Button,
-                    Node {
-                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
-                        margin: UiRect::left(Val::Px(5.0)),
+            row.spawn((
+                Button,
+                Node {
+                    padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
+                    margin: UiRect::left(Val::Px(5.0)),
+                    ..Default::default()
+                },
+                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                ViewButton { delta: -1 },
+            ))
+            .with_children(|p| {
+                p.spawn((
+                    Text::new("-"),
+                    TextFont {
+                        font_size: 24.0,
                         ..Default::default()
                     },
-                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
-                    DimButton { dim, delta: -1 },
-                ))
-                .with_children(|p| {
-                    p.spawn((
-                        Text::new("-"),
-                        TextFont { font_size: 24.0, ..Default::default() },
-                        TextColor::default(),
-                    ));
-                });
+                    TextColor::default(),
+                ));
+            });
 
-            row
-                .spawn((
-                    Button,
-                    Node {
-                        padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
-                        margin: UiRect::left(Val::Px(5.0)),
+            row.spawn((
+                Button,
+                Node {
+                    padding: UiRect::axes(Val::Px(5.0), Val::Px(2.0)),
+                    margin: UiRect::left(Val::Px(5.0)),
+                    ..Default::default()
+                },
+                BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                ViewButton { delta: 1 },
+            ))
+            .with_children(|p| {
+                p.spawn((
+                    Text::new("+"),
+                    TextFont {
+                        font_size: 24.0,
                         ..Default::default()
                     },
-                    BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
-                    DimButton { dim, delta: 1 },
-                ))
-                .with_children(|p| {
-                    p.spawn((
-                        Text::new("+"),
-                        TextFont { font_size: 24.0, ..Default::default() },
-                        TextColor::default(),
-                    ));
-                });
+                    TextColor::default(),
+                ));
+            });
         });
 }
 
 pub fn menu_actions(
-    mut interaction_q: Query<(&Interaction, Option<&DimButton>, Option<&StartButton>, Option<&ExitButton>), Changed<Interaction>>,
+    mut interaction_q: Query<
+        (
+            &Interaction,
+            Option<&ViewButton>,
+            Option<&StartButton>,
+            Option<&ExitButton>,
+        ),
+        Changed<Interaction>,
+    >,
     mut params: ResMut<WorldParams>,
     mut next_state: ResMut<NextState<AppState>>,
     mut exit: EventWriter<AppExit>,
 ) {
-    for (interaction, dim_button, start, exit_button) in &mut interaction_q {
+    for (interaction, view_button, start, exit_button) in &mut interaction_q {
         if *interaction != Interaction::Pressed {
             continue;
         }
 
-        if let Some(dim_button) = dim_button {
-            let value = match dim_button.dim {
-                Dimension::Width => &mut params.width,
-                Dimension::Depth => &mut params.depth,
-            };
-            *value = (*value + dim_button.delta).max(1);
+        if let Some(view_button) = view_button {
+            params.view_width = (params.view_width + view_button.delta).max(1);
         }
 
         if start.is_some() {
@@ -194,19 +195,12 @@ pub fn menu_actions(
     }
 }
 
-pub fn update_dim_texts(params: Res<WorldParams>, mut q: Query<(&DimText, &mut Text)>) {
+pub fn update_view_text(params: Res<WorldParams>, mut q: Query<&mut Text, With<ViewText>>) {
     if !params.is_changed() {
         return;
     }
-    for (dim, mut text) in &mut q {
-        let label = match dim.dim {
-            Dimension::Width => "Width:",
-            Dimension::Depth => "Depth:",
-        };
-        *text = Text::new(format!("{} {}", label, match dim.dim {
-            Dimension::Width => params.width,
-            Dimension::Depth => params.depth,
-        }));
+    for mut text in &mut q {
+        *text = Text::new(format!("View Width: {}", params.view_width));
     }
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,16 +1,20 @@
 use bevy::prelude::*;
 
+/// Size of one cubic chunk edge in blocks.
+pub const CHUNK_SIZE: i32 = 32;
+
+/// Maximum vertical height of the world in blocks.
+pub const MAX_HEIGHT: i32 = 128;
+
+/// Runtime-configurable world generation parameters.
 #[derive(Resource)]
 pub struct WorldParams {
-    pub width: i32,
-    pub depth: i32,
+    /// Number of chunks to generate outwards from the origin along each axis.
+    pub view_width: i32,
 }
 
 impl Default for WorldParams {
     fn default() -> Self {
-        Self {
-            width: 512,
-            depth: 512,
-        }
+        Self { view_width: 4 }
     }
 }


### PR DESCRIPTION
## Summary
- Generate terrain in 32×32×32 chunks up to 128 blocks high
- Let players choose chunk view width from the start menu
- Refactor world parameters and update project state documentation

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68ae18365a6c832380b745dda6004d73