### PR TITLE
Fix chunk LOD updates and remove seams

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -6,6 +6,7 @@
 - Perlin noise terrain generation on game start with corrected frequency for varied height.
 - World generation uses 32×32×32 chunks with a configurable view width radius and a maximum height of 128 blocks, plus stacked 2D noise and 3D noise caves.
 - Chunks stream infinitely as the player moves, meshed with a greedy algorithm and culled via camera frustum with distance-based LOD.
+- Nearby chunks automatically regenerate at full resolution and border voxels are populated to eliminate seams between chunks.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -10,3 +10,4 @@
 - Applied 3D Perlin noise to carve caves, cliffs, and ravines without exposing void spaces.
 - Switched to chunk-based world generation using 32×32×32 chunks with a configurable view width radius (default 4) and a maximum height of 128 blocks.
 - Added multithreaded infinite chunk streaming with greedy meshing, frustum culling, and distance-based LOD.
+- Chunks now upgrade to full resolution within three chunks of the player and generate neighbor border voxels to remove gaps between chunks.


### PR DESCRIPTION
## Summary
- Regenerate nearby chunks at full resolution and cancel outdated tasks
- Populate border voxels during meshing to eliminate gaps between chunks
- Document world generation upgrades in AGENT_INFO and project state

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68ae233413e883238117cafdf80a46ee