### PR TITLE
Fix chunk mesh offset causing gaps between chunks

### DIFF
--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -11,3 +11,4 @@
 - Switched to chunk-based world generation using 32×32×32 chunks with a configurable view width radius (default 4) and a maximum height of 128 blocks.
 - Added multithreaded infinite chunk streaming with greedy meshing, frustum culling, and distance-based LOD.
 - Chunks now upgrade to full resolution within three chunks of the player and generate neighbor border voxels to remove gaps between chunks.
+- Fixed an off-by-one vertex offset so adjacent chunk meshes connect without visible gaps.


### PR DESCRIPTION
## Summary
- shift chunk mesh vertices by LOD amount so adjacent meshes touch exactly
- document fix in AGENT_INFO

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae277ec2648323ba72c2a350443435