### PR TITLE
Reintroduce 3D noise and colorized terrain

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -4,9 +4,10 @@
 - Basic voxel world rendering with free camera controls.
 - Title screen with adjustable view width, Start Game and Exit buttons.
 - Perlin noise terrain generation on game start with corrected frequency for varied height.
-- World generation uses 32×32×32 chunks with a configurable view width radius and a maximum height of 128 blocks, plus stacked 2D noise and 3D noise caves.
+- World generation uses 32×32×32 chunks with a configurable view width radius and a maximum height of 128 blocks, combining stacked 2D noise with 3D noise caves for hills and plateaus.
 - Chunks stream infinitely as the player moves, meshed with a greedy algorithm and culled via camera frustum with distance-based LOD.
-- Nearby chunks automatically regenerate at full resolution and border voxels are populated to eliminate seams between chunks.
+- Nearby chunks automatically regenerate at full resolution and border voxels are populated to eliminate seams between chunks, fixing the previous chunk gap bug.
+- Surface blocks render green, the layer below brown, and deeper blocks gray.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -7,7 +7,8 @@
 - Corrected Perlin noise frequency so terrain heights vary properly.
 - Refactored gameplay, menu, player controls, and world resources into separate modules to slim down `main.rs`.
 - Stacked multiple 2D Perlin noise layers for wide-spread terrain variation.
-- Applied 3D Perlin noise to carve caves, cliffs, and ravines without exposing void spaces.
+- Reintroduced 3D Perlin noise to carve sparse caves and cliffs while adding hills and plateaus.
 - Switched to chunk-based world generation using 32×32×32 chunks with a configurable view width radius (default 4) and a maximum height of 128 blocks.
 - Added multithreaded infinite chunk streaming with greedy meshing, frustum culling, and distance-based LOD.
-- Chunks now upgrade to full resolution within three chunks of the player and generate neighbor border voxels to remove gaps between chunks.
+- Fixed chunk gap bug by generating neighbor border voxels and upgrading nearby chunks to full resolution.
+- Colored voxels: top blocks render green, subsoil brown, and underground stone gray.

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
-use bevy::prelude::*;
+use bevy::math::Affine3A;
 use bevy::pbr::MeshMaterial3d;
+use bevy::prelude::*;
 use bevy::render::mesh::{Indices, Mesh, Mesh3d};
 use bevy::render::primitives::{Aabb, Frustum};
 use bevy::tasks::{AsyncComputeTaskPool, Task};
-use bevy::math::Affine3A;
 use block_mesh::ndshape::{ConstShape3u32, Shape};
-use block_mesh::{greedy_quads, GreedyQuadsBuffer, MergeVoxel, Voxel, VoxelVisibility, RIGHT_HANDED_Y_UP_CONFIG};
+use block_mesh::{
+    GreedyQuadsBuffer, MergeVoxel, RIGHT_HANDED_Y_UP_CONFIG, Voxel, VoxelVisibility, greedy_quads,
+};
 use fastnoise_lite::{FastNoiseLite, NoiseType};
 use futures_lite::future;
 
@@ -83,11 +85,11 @@ impl Plugin for WorldPlugin {
     }
 }
 
-fn setup_chunk_material(
-    mut commands: Commands,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-) {
-    let material = materials.add(Color::srgb_u8(150, 150, 150));
+fn setup_chunk_material(mut commands: Commands, mut materials: ResMut<Assets<StandardMaterial>>) {
+    let material = materials.add(StandardMaterial {
+        base_color: Color::WHITE,
+        ..default()
+    });
     commands.insert_resource(ChunkMaterial(material));
 }
 
@@ -100,10 +102,7 @@ fn spawn_required_chunks(
     chunks: Query<&Chunk>,
 ) {
     let pool = AsyncComputeTaskPool::get();
-    let player_pos = player
-        .single()
-        .map(|t| t.translation)
-        .unwrap_or(Vec3::ZERO);
+    let player_pos = player.single().map(|t| t.translation).unwrap_or(Vec3::ZERO);
     let player_chunk = IVec3::new(
         (player_pos.x / CHUNK_SIZE as f32).floor() as i32,
         0,
@@ -113,7 +112,9 @@ fn spawn_required_chunks(
     // Despawn chunks far outside the view radius
     let mut to_remove = Vec::new();
     for (coord, entity) in map.entities.iter() {
-        let dist = (coord.x - player_chunk.x).abs().max((coord.z - player_chunk.z).abs());
+        let dist = (coord.x - player_chunk.x)
+            .abs()
+            .max((coord.z - player_chunk.z).abs());
         if dist > params.view_width + 2 {
             commands.entity(*entity).despawn();
             to_remove.push(*coord);
@@ -214,23 +215,29 @@ fn frustum_cull_chunks(
 // === Meshing ===
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-struct BoolVoxel(bool);
+enum BlockType {
+    Empty,
+    Grass,
+    Dirt,
+    Stone,
+}
 
-const EMPTY: BoolVoxel = BoolVoxel(false);
-const FULL: BoolVoxel = BoolVoxel(true);
+const EMPTY: BlockType = BlockType::Empty;
+const GRASS: BlockType = BlockType::Grass;
+const DIRT: BlockType = BlockType::Dirt;
+const STONE: BlockType = BlockType::Stone;
 
-impl Voxel for BoolVoxel {
+impl Voxel for BlockType {
     fn get_visibility(&self) -> VoxelVisibility {
-        if *self == EMPTY {
-            VoxelVisibility::Empty
-        } else {
-            VoxelVisibility::Opaque
+        match self {
+            BlockType::Empty => VoxelVisibility::Empty,
+            _ => VoxelVisibility::Opaque,
         }
     }
 }
 
-impl MergeVoxel for BoolVoxel {
-    type MergeValue = BoolVoxel;
+impl MergeVoxel for BlockType {
+    type MergeValue = BlockType;
     fn merge_value(&self) -> Self::MergeValue {
         *self
     }
@@ -250,29 +257,55 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32) -> Mesh {
     let shape = ConstShape3u32::<{ N }, { N }, { N }> {};
     let mut voxels = vec![EMPTY; (N * N * N) as usize];
 
+    // 2D terrain noise for varied heights
     let mut base = FastNoiseLite::with_seed(0);
     base.set_noise_type(Some(NoiseType::Perlin));
-    base.set_frequency(Some(0.005));
+    base.set_frequency(Some(0.002));
 
-    let mut detail = FastNoiseLite::with_seed(1);
+    let mut mid = FastNoiseLite::with_seed(1);
+    mid.set_noise_type(Some(NoiseType::Perlin));
+    mid.set_frequency(Some(0.01));
+
+    let mut detail = FastNoiseLite::with_seed(2);
     detail.set_noise_type(Some(NoiseType::Perlin));
-    detail.set_frequency(Some(0.02));
+    detail.set_frequency(Some(0.05));
+
+    // 3D noise for sparse caves and cliffs
+    let mut cave = FastNoiseLite::with_seed(3);
+    cave.set_noise_type(Some(NoiseType::Perlin));
+    cave.set_frequency(Some(0.03));
 
     for z in 0..=size + 1 {
         for x in 0..=size + 1 {
             let wx = coord.x * CHUNK_SIZE + ((x as i32 - 1) * lod as i32);
             let wz = coord.z * CHUNK_SIZE + ((z as i32 - 1) * lod as i32);
-            let base_val = base.get_noise_2d(wx as f32, wz as f32);
-            let detail_val = detail.get_noise_2d(wx as f32, wz as f32);
-            let height = ((base_val * 20.0) + (detail_val * 5.0) + 20.0)
-                .round()
-                .clamp(1.0, (MAX_HEIGHT - 1) as f32) as i32;
+
+            let h_base = base.get_noise_2d(wx as f32, wz as f32) * 25.0;
+            let h_mid = mid.get_noise_2d(wx as f32, wz as f32) * 10.0;
+            let h_detail = detail.get_noise_2d(wx as f32, wz as f32) * 3.0;
+            let mut height = h_base + h_mid + h_detail + 40.0;
+            height = (height / 4.0).round() * 4.0; // create plateaus
+            let height = height.clamp(1.0, (MAX_HEIGHT - 1) as f32).round() as i32;
+
             for y in 0..=size + 1 {
                 let wy = coord.y * CHUNK_SIZE + ((y as i32 - 1) * lod as i32);
-                if wy <= height {
-                    let idx = shape.linearize([x, y, z]) as usize;
-                    voxels[idx] = FULL;
+                if wy > height {
+                    continue;
                 }
+
+                let noise = cave.get_noise_3d(wx as f32, wy as f32, wz as f32);
+                if noise > 0.8 {
+                    continue; // carve cave
+                }
+
+                let idx = shape.linearize([x, y, z]) as usize;
+                voxels[idx] = if wy == height {
+                    GRASS
+                } else if wy == height - 1 {
+                    DIRT
+                } else {
+                    STONE
+                };
             }
         }
     }
@@ -289,6 +322,7 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32) -> Mesh {
 
     let mut positions: Vec<[f32; 3]> = Vec::new();
     let mut normals: Vec<[f32; 3]> = Vec::new();
+    let mut colors: Vec<[f32; 4]> = Vec::new();
     let mut indices: Vec<u32> = Vec::new();
 
     for (face, group) in RIGHT_HANDED_Y_UP_CONFIG
@@ -301,15 +335,27 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32) -> Mesh {
             positions.extend_from_slice(&face.quad_mesh_positions(quad, lod as f32));
             normals.extend_from_slice(&face.quad_mesh_normals());
             indices.extend_from_slice(&face.quad_mesh_indices(start));
+
+            let voxel = voxels[shape.linearize(quad.minimum) as usize];
+            let color = match voxel {
+                GRASS => [0.1, 0.8, 0.1, 1.0],
+                DIRT => [0.55, 0.27, 0.07, 1.0],
+                STONE => [0.6, 0.6, 0.6, 1.0],
+                _ => [1.0, 1.0, 1.0, 1.0],
+            };
+            colors.extend_from_slice(&[color; 4]);
         }
     }
 
     use bevy::render::mesh::PrimitiveTopology;
     use bevy::render::render_asset::RenderAssetUsages;
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    );
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
     mesh.insert_indices(Indices::U32(indices));
     mesh
 }
-


### PR DESCRIPTION
## Summary
- Document fixed chunk-gap issue
- Reintroduce 3D Perlin noise with hills, plateaus, and rare caves
- Color terrain layers: grass, dirt, and stone via vertex colors

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68ae2f93c41c83238b38ddbaa2199500