### PR TITLE
Refine terrain noise and fix mesh offset

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -4,9 +4,11 @@
 - Basic voxel world rendering with free camera controls.
 - Title screen with adjustable view width, Start Game and Exit buttons.
 - Perlin noise terrain generation on game start with corrected frequency for varied height.
-- World generation uses 32×32×32 chunks with a configurable view width radius and a maximum height of 128 blocks, plus stacked 2D noise and 3D noise caves.
+- World generation uses 32×32×32 chunks with a configurable view width radius and a maximum height of 128 blocks, combining stacked 2D noise with 3D noise caves for hills and plateaus.
 - Chunks stream infinitely as the player moves, meshed with a greedy algorithm and culled via camera frustum with distance-based LOD.
-- Nearby chunks automatically regenerate at full resolution and border voxels are populated to eliminate seams between chunks.
+- Nearby chunks automatically regenerate at full resolution and border voxels are populated to eliminate seams between chunks, fixing the previous chunk gap bug.
+- Surface blocks render green, the layer below brown, and deeper blocks gray.
+- Terrain noise retuned for noticeable hills and plateaus, and chunk mesh positions corrected so all faces render.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -7,7 +7,9 @@
 - Corrected Perlin noise frequency so terrain heights vary properly.
 - Refactored gameplay, menu, player controls, and world resources into separate modules to slim down `main.rs`.
 - Stacked multiple 2D Perlin noise layers for wide-spread terrain variation.
-- Applied 3D Perlin noise to carve caves, cliffs, and ravines without exposing void spaces.
+- Reintroduced 3D Perlin noise to carve sparse caves and cliffs while adding hills and plateaus.
 - Switched to chunk-based world generation using 32×32×32 chunks with a configurable view width radius (default 4) and a maximum height of 128 blocks.
 - Added multithreaded infinite chunk streaming with greedy meshing, frustum culling, and distance-based LOD.
-- Chunks now upgrade to full resolution within three chunks of the player and generate neighbor border voxels to remove gaps between chunks.
+- Fixed chunk gap bug by generating neighbor border voxels and upgrading nearby chunks to full resolution.
+- Colored voxels: top blocks render green, subsoil brown, and underground stone gray.
+- Tuned noise amplitudes for varied hills and corrected mesh offset so all block faces render.


### PR DESCRIPTION
## Summary
- Retune layered Perlin noise and clamp heights for visible hills and plateaus
- Offset quad vertices by LOD to render all chunk faces correctly
- Document terrain noise tuning and mesh offset fix

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68ae2f93c41c83238b38ddbaa2199500