### PR TITLE
Improve distant chunk LOD and mesh color accuracy

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -11,7 +11,7 @@
 - Terrain noise retuned for noticeable hills and plateaus, and chunk mesh positions corrected so all faces render.
 - Terrain height now stacks five configurable noise layers adjustable from the title screen and saved to `settings.json`.
 - Pressing `P` in-game returns to the title screen and removes active world entities.
-- Distant low-detail chunks now approximate height variations and display the correct block colors so terrain matches when approached.
+- Chunks retain full detail within an eight-chunk radius, and distant low-detail meshes sample the surface block so colors remain accurate when approached.
 - Chunks now spawn in stacked vertical layers up to eight chunks high, enabling a fully 3D world grid.
 
 ## WIP

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -16,3 +16,4 @@
 - Added menu controls for five stacked terrain noise layers, editable and persisted to `settings.json` with the `L` key.
 - Pressing `P` during gameplay returns to the title screen and cleans up the world and player entities.
 - Chunk generation now spans the vertical axis, spawning up to eight stacked chunk layers for a full 3D grid.
+- Reduced-detail chunk rendering now begins beyond eight chunks from the player and samples the top surface block so distant terrain colors stay accurate.


### PR DESCRIPTION
## Summary
- Delay chunk LOD drop until eight-chunk radius
- Sample highest block in each voxel to color distant meshes correctly

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b22505e0d08323ac2a8dbfd27fd909