### PR TITLE
Cross-fade LOD transitions and cache surface colors

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -13,6 +13,7 @@
 - Pressing `P` in-game returns to the title screen and removes active world entities.
 - Chunks retain full detail within an eight-chunk radius, and distant low-detail meshes sample the surface block so colors remain accurate when approached.
 - Chunks now spawn in stacked vertical layers up to eight chunks high, enabling a fully 3D world grid.
+- LOD swaps cross-fade between chunk meshes to reduce visible popping, and per-chunk surface colors are cached to speed LOD toggling.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -17,3 +17,4 @@
 - Pressing `P` during gameplay returns to the title screen and cleans up the world and player entities.
 - Chunk generation now spans the vertical axis, spawning up to eight stacked chunk layers for a full 3D grid.
 - Reduced-detail chunk rendering now begins beyond eight chunks from the player and samples the top surface block so distant terrain colors stay accurate.
+- LOD swaps now cross-fade chunk meshes to mask pops, and surface colors are cached per chunk so distant meshes reuse them when toggling detail.


### PR DESCRIPTION
## Summary
- Smoothly cross-fade chunk meshes when switching LOD to hide popping
- Cache per-chunk surface colors and reuse them for low-detail meshes

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68b2285cea2c83238d7d970b9194e2f8