### PR TITLE
Add cliffs, boulders, and trees to terrain generation

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -13,6 +13,7 @@
 - Pressing `P` in-game returns to the title screen and removes active world entities.
 - Chunks retain full detail within an eight-chunk radius, and distant low-detail meshes sample the surface block so colors remain accurate when approached.
 - Chunks now spawn in stacked vertical layers up to eight chunks high, enabling a fully 3D world grid.
+- Ridged noise adds cliffs and overhangs while stone boulders and basic wood-and-leaf trees populate the terrain.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -17,3 +17,4 @@
 - Pressing `P` during gameplay returns to the title screen and cleans up the world and player entities.
 - Chunk generation now spans the vertical axis, spawning up to eight stacked chunk layers for a full 3D grid.
 - Reduced-detail chunk rendering now begins beyond eight chunks from the player and samples the top surface block so distant terrain colors stay accurate.
+- Cliffs and overhangs form using extra ridged noise, with random stone boulders and simple wood-and-leaf trees populating chunk surfaces.


### PR DESCRIPTION
## Summary
- Introduce wood and leaf block types to support natural features
- Extend chunk generation with ridged noise for cliffs and overhangs
- Spawn stone boulders and simple trees across high-detail terrain

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68b22d00a60083239eea09bb269cab08