### PR TITLE
Add cliffs, boulders, and trees to terrain generation

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -13,6 +13,7 @@
 - Pressing `P` in-game returns to the title screen and removes active world entities.
 - Chunks retain full detail within an eight-chunk radius, and distant low-detail meshes sample the surface block so colors remain accurate when approached.
 - Chunks now spawn in stacked vertical layers up to eight chunks high, enabling a fully 3D world grid.
+- Ridged noise adds cliffs and overhangs while rarer stone boulders and density-driven, taller wood-and-leaf trees populate the terrain.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -17,3 +17,4 @@
 - Pressing `P` during gameplay returns to the title screen and cleans up the world and player entities.
 - Chunk generation now spans the vertical axis, spawning up to eight stacked chunk layers for a full 3D grid.
 - Reduced-detail chunk rendering now begins beyond eight chunks from the player and samples the top surface block so distant terrain colors stay accurate.
+- Cliffs and overhangs form using extra ridged noise, with rarer stone boulders and noise-driven forests of taller wood-and-leaf trees.

--- a/src/world.rs
+++ b/src/world.rs
@@ -241,12 +241,16 @@ enum BlockType {
     Grass,
     Dirt,
     Stone,
+    Wood,
+    Leaf,
 }
 
 const EMPTY: BlockType = BlockType::Empty;
 const GRASS: BlockType = BlockType::Grass;
 const DIRT: BlockType = BlockType::Dirt;
 const STONE: BlockType = BlockType::Stone;
+const WOOD: BlockType = BlockType::Wood;
+const LEAF: BlockType = BlockType::Leaf;
 
 impl Voxel for BlockType {
     fn get_visibility(&self) -> VoxelVisibility {
@@ -277,6 +281,24 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32, settings: &NoiseSettings) ->
 
     let shape = ConstShape3u32::<{ N }, { N }, { N }> {};
     let mut voxels = vec![EMPTY; (N * N * N) as usize];
+    let size_i32 = size as i32;
+
+    // helper closure to place blocks via world coordinates
+    let set_block = |voxels: &mut Vec<BlockType>, wx: i32, wy: i32, wz: i32, block: BlockType| {
+        let lx = ((wx - coord.x * CHUNK_SIZE) / lod as i32) + 1;
+        let ly = ((wy - coord.y * CHUNK_SIZE) / lod as i32) + 1;
+        let lz = ((wz - coord.z * CHUNK_SIZE) / lod as i32) + 1;
+        if lx >= 0
+            && lx <= size_i32 + 1
+            && ly >= 0
+            && ly <= size_i32 + 1
+            && lz >= 0
+            && lz <= size_i32 + 1
+        {
+            let idx = shape.linearize([lx as u32, ly as u32, lz as u32]) as usize;
+            voxels[idx] = block;
+        }
+    };
 
     // 2D terrain noise layers for varied heights
     let mut noises = Vec::new();
@@ -291,6 +313,23 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32, settings: &NoiseSettings) ->
     let mut cave = FastNoiseLite::with_seed(3);
     cave.set_noise_type(Some(NoiseType::Perlin));
     cave.set_frequency(Some(0.05));
+
+    // Noise for cliffs, boulders and trees
+    let mut cliff = FastNoiseLite::with_seed(99);
+    cliff.set_noise_type(Some(NoiseType::Perlin));
+    cliff.set_frequency(Some(0.01));
+
+    let mut boulder_noise = FastNoiseLite::with_seed(1337);
+    boulder_noise.set_noise_type(Some(NoiseType::Perlin));
+    boulder_noise.set_frequency(Some(0.02));
+
+    let mut tree_density = FastNoiseLite::with_seed(4242);
+    tree_density.set_noise_type(Some(NoiseType::Perlin));
+    tree_density.set_frequency(Some(0.005));
+
+    let mut tree_scatter = FastNoiseLite::with_seed(4243);
+    tree_scatter.set_noise_type(Some(NoiseType::Perlin));
+    tree_scatter.set_frequency(Some(0.1));
 
     for z in 0..=size + 1 {
         for x in 0..=size + 1 {
@@ -307,11 +346,15 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32, settings: &NoiseSettings) ->
                     height += (val * amp) as i32;
                 }
             }
+            // additional ridged noise for cliffs
+            let ridge = cliff.get_noise_2d(wx as f32, wz as f32).abs();
+            height += (ridge * 20.0) as i32;
             let height = height.clamp(1, MAX_HEIGHT - 1) as i32;
+            let max_y = height + 8;
 
             for y in 1..=size + 1 {
                 let wy = coord.y * CHUNK_SIZE + ((y as i32 - 1) * lod as i32);
-                if wy > height {
+                if wy > max_y {
                     continue;
                 }
 
@@ -320,27 +363,69 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32, settings: &NoiseSettings) ->
 
                 for offset in (0..lod).rev() {
                     let sample_y = wy + offset as i32;
-                    if sample_y > height {
+                    if sample_y > max_y {
                         continue;
                     }
 
                     let noise = cave.get_noise_3d(wx as f32, sample_y as f32, wz as f32);
-                    if noise > 0.9 {
-                        continue; // carve cave
-                    }
-
-                    block = if sample_y == height {
-                        GRASS
-                    } else if sample_y == height - 1 {
-                        DIRT
+                    if sample_y <= height {
+                        if noise > 0.9 {
+                            continue;
+                        }
+                        block = if sample_y == height {
+                            GRASS
+                        } else if sample_y == height - 1 {
+                            DIRT
+                        } else {
+                            STONE
+                        };
+                    } else if noise < -0.3 {
+                        block = STONE;
                     } else {
-                        STONE
-                    };
+                        continue;
+                    }
                     break;
                 }
 
                 if block != EMPTY {
                     voxels[idx] = block;
+                }
+            }
+
+            if lod == 1 {
+                let b_val = boulder_noise.get_noise_2d(wx as f32, wz as f32);
+                let density = (tree_density.get_noise_2d(wx as f32, wz as f32) + 1.0) / 2.0;
+                let scatter = (tree_scatter.get_noise_2d(wx as f32, wz as f32) + 1.0) / 2.0;
+                if b_val > 0.9 {
+                    let radius = 1 + ((b_val - 0.9) * 10.0) as i32;
+                    for by in 0..=radius {
+                        for bx in -radius..=radius {
+                            for bz in -radius..=radius {
+                                if bx * bx + by * by + bz * bz <= radius * radius {
+                                    set_block(&mut voxels, wx + bx, height + by, wz + bz, STONE);
+                                }
+                            }
+                        }
+                    }
+                } else if scatter < density * density * 0.5 {
+                    let variant =
+                        (tree_scatter.get_noise_2d(wx as f32 + 1000.0, wz as f32 + 1000.0) + 1.0)
+                            / 2.0;
+                    let trunk_h = 10 + (variant * 6.0) as i32;
+                    for ty in 1..=trunk_h {
+                        set_block(&mut voxels, wx, height + ty, wz, WOOD);
+                    }
+                    let top = height + trunk_h;
+                    let canopy = 3 + (variant * 2.0) as i32;
+                    for dx in -canopy..=canopy {
+                        for dz in -canopy..=canopy {
+                            for dy in 0..=canopy {
+                                if dx * dx + dz * dz + dy * dy <= canopy * canopy {
+                                    set_block(&mut voxels, wx + dx, top + dy, wz + dz, LEAF);
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -383,6 +468,8 @@ fn build_mesh<const N: u32>(coord: IVec3, lod: u32, settings: &NoiseSettings) ->
                 GRASS => [0.1, 0.8, 0.1, 1.0],
                 DIRT => [0.55, 0.27, 0.07, 1.0],
                 STONE => [0.6, 0.6, 0.6, 1.0],
+                WOOD => [0.55, 0.27, 0.07, 1.0],
+                LEAF => [0.2, 0.6, 0.2, 1.0],
                 _ => [1.0, 1.0, 1.0, 1.0],
             };
             colors.extend_from_slice(&[color; 4]);


### PR DESCRIPTION
## Summary
- Introduce wood and leaf block types to support natural features
- Extend chunk generation with ridged noise for cliffs and overhangs
- Spawn stone boulders and trees across high-detail terrain using density-based forests and rarer boulders

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68b22d00a60083239eea09bb269cab08