### PR TITLE
Improve tree and boulder generation

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -13,7 +13,7 @@
 - Pressing `P` in-game returns to the title screen and removes active world entities.
 - Chunks retain full detail within an eight-chunk radius, and distant low-detail meshes sample the surface block so colors remain accurate when approached.
 - Chunks now spawn in stacked vertical layers up to eight chunks high, enabling a fully 3D world grid.
-- Ridged noise adds cliffs and overhangs while rarer stone boulders and density-driven, taller wood-and-leaf trees populate the terrain.
+- Ridged noise adds cliffs and overhangs while boulder generation now uses density and scatter noise with irregular shapes, and trees vary trunk size with collision-safe placement.
 
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -18,3 +18,5 @@
 - Chunk generation now spans the vertical axis, spawning up to eight stacked chunk layers for a full 3D grid.
 - Reduced-detail chunk rendering now begins beyond eight chunks from the player and samples the top surface block so distant terrain colors stay accurate.
 - Cliffs and overhangs form using extra ridged noise, with rarer stone boulders and noise-driven forests of taller wood-and-leaf trees.
+ - Boulder placement now mirrors tree generation with separate density and scatter noise and irregular 3D Perlin shapes.
+ - Tree trunks randomly span 1×1 to 3×3 blocks with proportionally scaled height and canopy radius, skipping spawn when trunks would collide.


### PR DESCRIPTION
## Summary
- Spawn boulders via density/scatter noise and irregular 3D Perlin shapes
- Add variable tree trunk sizes with canopy scaling and collision checks
- Document new generation features

## Testing
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b238e56e5c8323bd70c3899ea77eff