### PR TITLE
Cache high-detail chunk meshes for seamless LOD upgrades

### DIFF
--- a/ProjectState.md
+++ b/ProjectState.md
@@ -15,5 +15,7 @@
 - Chunks now spawn in stacked vertical layers up to eight chunks high, enabling a fully 3D world grid.
 - Ridged noise adds cliffs and overhangs while boulder generation now uses density and scatter noise with irregular shapes, and trees vary trunk size with collision-safe placement.
 
+- High-detail chunk meshes are cached ahead of time so low-precision chunks upgrade instantly without gaps, reducing regeneration stutter.
+
 ## WIP
 - None

--- a/src/AGENT_INFO.md
+++ b/src/AGENT_INFO.md
@@ -19,4 +19,5 @@
 - Reduced-detail chunk rendering now begins beyond eight chunks from the player and samples the top surface block so distant terrain colors stay accurate.
 - Cliffs and overhangs form using extra ridged noise, with rarer stone boulders and noise-driven forests of taller wood-and-leaf trees.
  - Boulder placement now mirrors tree generation with separate density and scatter noise and irregular 3D Perlin shapes.
- - Tree trunks randomly span 1×1 to 3×3 blocks with proportionally scaled height and canopy radius, skipping spawn when trunks would collide.
+- Tree trunks randomly span 1×1 to 3×3 blocks with proportionally scaled height and canopy radius, skipping spawn when trunks would collide.
+ - Chunk meshes now cache high-detail versions just beyond the close-range LOD radius so upgrades swap instantly without gaps, reducing regeneration work.


### PR DESCRIPTION
## Summary
- pre-cache high precision chunk meshes and swap them in without despawning low LOD first
- store generated meshes in a cache so revisits and upgrades avoid regeneration gaps
- document new caching behavior

## Testing
- `cargo check` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2463610308323a9f44bfbed1279f2